### PR TITLE
unit-file: simplify & make more reliable

### DIFF
--- a/templates/container.service.epp
+++ b/templates/container.service.epp
@@ -5,9 +5,9 @@ Description=<%= $description %>
 Restart=always
 User=<%= $user %>
 Group=<%= $group %>
-ExecStartPre=-/usr/bin/podman pull <%= $image %>
-ExecStartPre=-/usr/bin/bash -c "(/usr/bin/podman ps --format '{{.Names}}' | /usr/bin/grep -Eq '^<%= $sanitised_title %>$') && /usr/bin/podman kill <%= $sanitised_title %> || /bin/true"
-ExecStartPre=-/usr/bin/bash -c "((/usr/bin/podman ps -a --format '{{.Names}}' | /usr/bin/grep -Eq '^<%= $sanitised_title %>$') && /usr/bin/podman rm <%= $sanitised_title %> || /bin/true)"
+ExecStartPre=/usr/bin/podman pull <%= $image %>
+ExecStartPre=-/usr/bin/podman kill <%= $sanitised_title %>
+ExecStartPre=-/usr/bin/podman rm <%= $sanitised_title %>
 ExecStart=/usr/bin/podman run \
 <% $ports.each |$port| { -%>
   --publish <%= $port %> \
@@ -16,9 +16,9 @@ ExecStart=/usr/bin/podman run \
   --name <%= $sanitised_title %> \
   <%= $image %> \
   <% if $command { %> <%= $command %><% } %>
-ExecStop=-/usr/bin/podman stop -t 10 <%= $sanitised_title %>
-ExecReload=-/usr/bin/podman stop -t 10 <%= $sanitised_title %>
-ExecReload=-/usr/bin/podman rm <%= $sanitised_title %>
+ExecStop=/usr/bin/podman stop -t 10 <%= $sanitised_title %>
+ExecReload=/usr/bin/podman stop -t 10 <%= $sanitised_title %>
+ExecReload=/usr/bin/podman rm <%= $sanitised_title %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When some `Exec*` statements fail, systemd should be aware of it, and
mark the service as failed. Those see their `=-` (which means lax exit
code checking) changed to the stricter `=`.
The other `Exec*` statements keep their `=-` as they are not critical,
but can be simplified, as their exit status doesn't matter.