### PR TITLE
Update unit file template to RHEL8.3 equivalent (podman 2.2.1)

### DIFF
--- a/templates/container.service.epp
+++ b/templates/container.service.epp
@@ -6,6 +6,8 @@
 | -%>
 [Unit]
 Description=<%= $description %>
+Wants=network.target
+After=network-online.target
 <% if $depends_on_svc != undef { -%>
 After=<%= $depends_on_svc %>
 Requires=<%= $depends_on_svc %>
@@ -18,12 +20,13 @@ TimeoutStartSec=5m
 EnvironmentFile=<%= $environment_file %>
 
 
-ExecStartPre=-/usr/bin/bash -c "((/usr/bin/podman ps -a --format '{{.Names}}' | /usr/bin/grep -Eq '^<%= $sanitised_title %>-container$') && /usr/bin/podman rm <%= $sanitised_title %>-container || /bin/true)"
-ExecStartPre=/usr/bin/rm -f /%T/%n-pid /%T/%n-cid
+ExecStartPre=/bin/rm -f %t/%N.pid %t/%N.ctr-id
 
 ExecStart=/usr/bin/podman run \
-  --conmon-pidfile=/%T/%n-pid \
-  --cidfile=/%T/%n-cid \
+  --conmon-pidfile=%t/%N.pid \
+  --cidfile=%t/%N.ctr-id \
+  --cgroups=no-conmon \
+  --replace \
   --name %N \
   --detach \
   $VOLUMES \
@@ -32,11 +35,12 @@ ExecStart=/usr/bin/podman run \
   $PODMAN_EXTRA_ARGS \
   ${IMAGE}:${TAG} $CONTAINER_EXTRA_FLAGS
 
-ExecStop=/usr/bin/sh -c "/usr/bin/podman rm -f `cat /%T/%n-cid`"
+ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.ctr-id -t 10
+ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%N.ctr-id
 
 RestartSec=30
 KillMode=none
-PIDFile=/%T/%n-pid
+PIDFile=%t/%N.pid
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target default.target


### PR DESCRIPTION
%T is a temporary file path where as the `cid` and `pid` files are not temporary and need to follow the whole lifecycle of the unit runtime.
This causes huge problems after a few days when systemd-tmpfiles triggers the cleanup of old files in temporary folders. At that point the `cid` and `pid` files cease to exist and systemctl start/stop/restart do not work as expected anymore for these units.